### PR TITLE
allow executing commands sequentially

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk add --update --no-cache \
     ca-certificates \
     bash \
     aws-cli \
-    expect \
     && apk add --update --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
     aws-session-manager-plugin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM alpine:3.20 AS ssm-builder
-
-RUN apk add dpkg curl; \
-    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
-    dpkg -x session-manager-plugin.deb session-manager-plugin
-
-
 FROM alpine:3.20
 
 RUN apk add --update --no-cache \
@@ -13,11 +6,9 @@ RUN apk add --update --no-cache \
     ca-certificates \
     bash \
     aws-cli \
-    gcompat \
-    && rm -rf /var/cache/apk/*
-
-COPY --from=ssm-builder /session-manager-plugin/usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
-RUN chmod +x /usr/local/bin/session-manager-plugin
+    expect \
+    && apk add --update --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    aws-session-manager-plugin
 
 COPY update.sh /bin/
 COPY ecs-deploy /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-FROM alpine:3.9
+FROM alpine:3.20
 
 RUN apk add --update --no-cache \
     curl \
     jq \
     ca-certificates \
     bash \
-    python \
-    && python -m ensurepip \
-    && rm -r /usr/lib/python*/ensurepip \
-    && pip install --upgrade pip setuptools \
-    awscli --ignore-installed \
-    && rm -r /root/.cache
+    aws-cli \
+    && rm -rf /var/cache/apk/*
 
 COPY update.sh /bin/
 COPY ecs-deploy /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM alpine:3.20 AS ssm-builder
+
+RUN apk add dpkg curl; \
+    curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"; \
+    dpkg -x session-manager-plugin.deb session-manager-plugin
+
+
 FROM alpine:3.20
 
 RUN apk add --update --no-cache \
@@ -6,7 +13,11 @@ RUN apk add --update --no-cache \
     ca-certificates \
     bash \
     aws-cli \
+    gcompat \
     && rm -rf /var/cache/apk/*
+
+COPY --from=ssm-builder /session-manager-plugin/usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
+RUN chmod +x /usr/local/bin/session-manager-plugin
 
 COPY update.sh /bin/
 COPY ecs-deploy /bin/

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ run simultaneously with the updating of the services.
 
 If `exec_commands` are set it's also required to provide an `exec_service` where
 they will be executed. This can be used to specify commands that need to run
-sequentially before any `services` are deployed or `tasks` are started (but an
-unsuccessful exit code will not stop the deployment process).
+sequentially and complete successfully before any `services` are deployed or
+`tasks` are started.
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Based on https://github.com/joshdvir/drone-ecs-deploy and https://github.com/sil
 
 You will need to set the `cluster`, `image`, `region` and `role` properties in
 your drone config and additionally the `services` (to update ECS services),
-`tasks` (for running one-off tasks) and `commands` (for executing commands
+`tasks` (for running one-off tasks) and `exec_commands` (for executing commands
 before deployment) properties.
 
 Each entry in `services` will change the service with the same name, changing
@@ -22,10 +22,11 @@ equivalent to one executed task and `CMD` (in Docker) will be set to this
 value. It's not guaranteed, that the tasks will execute in order, and they will
 run simultaneously with the updating of the services.
 
-If `commands` are set it's also required to provide an `exec_service` where they
-will be executed. This can be used to specify commands that need to run
-sequentially and need to finish successfully before any `services` are deployed
-or `tasks` are started.
+If `exec_commands` are set it's also required to provide an `exec_service` where
+they will be executed. This can be used to specify commands that need to run
+sequentially before any `services` are deployed or `tasks` are started (but an
+unsuccessful exit code will not stop the deployment process).
+
 ```yaml
 steps:
   ...
@@ -37,7 +38,7 @@ steps:
     role: <role-arn>
     exec_service:
       - service-a
-    commands:
+    exec_commands:
       - ./predeploy.sh
     services:
       - service-a
@@ -54,7 +55,7 @@ steps:
 See [LICENSE](LICENSE) for full details.
 
 ```
-Copyright (C) 2019 Formunauts GmbH
+Copyright (C) 2024 Formunauts GmbH
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ Based on https://github.com/joshdvir/drone-ecs-deploy and https://github.com/sil
 
 You will need to set the `cluster`, `image`, `region` and `role` properties in
 your drone config and additionally the `services` (to update ECS services) and
-`tasks` (for running one-off tasks) properties.
+`tasks` (for running one-off tasks) properties. The `predploy_tasks` property
+can be used to specify tasks that need to run in order and finish successfully
+before any `services` are deployed (the `tasks` will run out of order,
+simultaneously with updating the `services`).
 
 Each entry in `services` will change the service with the same name, changing
 the image in the task definition and update the service with the new definition.
 
-If `tasks` is set, it's also required to provide the `task_definition` property,
-as it can't be determined automatically (like with services).
+If `tasks` or `predeploy_tasks` is set, it's also required to provide the
+`task_definition` property, as it can't be determined automatically (like with
+services).
 
 Each line is equivalent to one executed task and `CMD` (in Docker) will be set
 to this value. It's not guaranteed, that the tasks will execute in order.

--- a/README.md
+++ b/README.md
@@ -9,22 +9,23 @@ Based on https://github.com/joshdvir/drone-ecs-deploy and https://github.com/sil
 ## Usage
 
 You will need to set the `cluster`, `image`, `region` and `role` properties in
-your drone config and additionally the `services` (to update ECS services) and
-`tasks` (for running one-off tasks) properties. The `predploy_tasks` property
-can be used to specify tasks that need to run in order and finish successfully
-before any `services` are deployed (the `tasks` will run out of order,
-simultaneously with updating the `services`).
+your drone config and additionally the `services` (to update ECS services),
+`tasks` (for running one-off tasks) and `commands` (for executing commands
+before deployment) properties.
 
 Each entry in `services` will change the service with the same name, changing
 the image in the task definition and update the service with the new definition.
 
-If `tasks` or `predeploy_tasks` is set, it's also required to provide the
-`task_definition` property, as it can't be determined automatically (like with
-services).
+If `tasks` is set, it's also required to provide the `task_definition` property,
+as it can't be determined automatically (like with services). Each line is
+equivalent to one executed task and `CMD` (in Docker) will be set to this
+value. It's not guaranteed, that the tasks will execute in order, and they will
+run simultaneously with the updating of the services.
 
-Each line is equivalent to one executed task and `CMD` (in Docker) will be set
-to this value. It's not guaranteed, that the tasks will execute in order.
-
+If `commands` are set it's also required to provide an `exec_service` where they
+will be executed. This can be used to specify commands that need to run
+sequentially and need to finish successfully before any `services` are deployed
+or `tasks` are started.
 ```yaml
 steps:
   ...
@@ -34,6 +35,10 @@ steps:
     image: <image-name>
     region: <aws-region>
     role: <role-arn>
+    exec_service:
+      - service-a
+    commands:
+      - ./predeploy.sh
     services:
       - service-a
       - service-b

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -6,6 +6,7 @@ ECS_CLI="$AWS_CLI --output json ecs"
 CLUSTER=false
 SERVICE=false
 COMMAND=false
+WAIT=false
 IMAGE="latest"
 TASK_DEFINITION=false
 MAX_DEFINITIONS=2
@@ -150,12 +151,45 @@ function runTask() {
     printf "Using overrides: %s\n" $overrides
   fi
 
-  $ECS_CLI run-task $DEBUG \
+  task=$($ECS_CLI run-task $DEBUG \
     --cluster $CLUSTER \
     --task-definition $TASK_DEFINITION_ARN \
-    --overrides "$overrides"
+    --overrides "$overrides")
+
+  printf "$task\n"
+
+  TASK_ARN=$(echo "$task" | jq -r ".tasks[0].taskArn")
 
   printf "Done running task %s on %s...\n" $TASK_DEFINITION_ARN $CLUSTER
+}
+
+function waitForTask() {
+  printf "Waiting for task %s on %s to finish..." $TASK_ARN $CLUSTER
+
+  every=2
+  count=0
+
+  while [ $count -lt $TIMEOUT ]; do
+    task=$($ECS_CLI describe-tasks $DEBUG \
+      --cluster $CLUSTER \
+      --tasks $TASK_ARN)
+    LAST_STATUS=$(echo "$task" | jq -r ".tasks[0].lastStatus")
+    if [ $LAST_STATUS == "STOPPED" ]; then
+      echo "Done waiting for task to finish..."
+      EXIT_CODE=$(echo $task | jq -r ".tasks[0].containers[0].exitCode")
+      if [ $EXIT_CODE -eq 0 ]; then
+        echo "Task finished successfully!"
+        count=$TIMEOUT
+      else
+        echo "Task not successful!"
+        echo "Aborting!"
+        exit 1
+      fi
+    else
+      sleep $every
+      count=$(($count + $every))
+    fi
+  done
 }
 
 function waitForDeployment() {
@@ -226,6 +260,9 @@ do
     COMMAND="$2"
     shift
     ;;
+    -w | --wait)
+    WAIT=true
+    ;;
     -d|--task-definition)
     TASK_DEFINITION="$2"
     shift
@@ -263,6 +300,9 @@ printf "New task definition ARN: %s\n" $TASK_DEFINITION_ARN
 if [ $SERVICE == false ]; then
   if [[ $COMMAND != false ]]; then
     runTask
+    if [[ $WAIT != false ]]; then
+      waitForTask
+    fi
   fi
 else
   deployService

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -2,7 +2,7 @@
 
 AWS_CLI=$(which aws)
 ECS_CLI="$AWS_CLI --output json ecs"
-SSM_CLI="unbuffer $AWS_CLI --output json ssm"
+SSM_CLI="$AWS_CLI --output json ssm"
 
 CLUSTER=false
 SERVICE=false
@@ -137,6 +137,23 @@ function deployService() {
   printf "Done deploying service %s to %s...\n" $SERVICE $CLUSTER
 }
 
+waitForSSMCommand() {
+  every=2
+  count=0
+
+  while [ $count -lt $TIMEOUT ]; do
+    details=$($SSM_CLI list-command-invocations --command-id "$SSM_COMMAND_ID" --details)
+    COMMAND_OUTPUT=$(echo "$details" | jq -r '.CommandInvocations[].CommandPlugins[].Output')
+    COMMAND_EXIT_CODE=$(echo "$details" | jq -r '.CommandInvocations[].CommandPlugins[].ResponseCode')
+    if [ $COMMAND_EXIT_CODE -gt -1 ]; then
+      break
+    else
+      sleep $every
+      count=$(($count + $every))
+    fi
+  done
+}
+
 execCommand() {
   printf "Executing command '%s' in service %s of %s...\n" "$COMMAND" $SERVICE $CLUSTER
 
@@ -157,7 +174,7 @@ execCommand() {
       jq -r '.[]'
   )"
   for container in $container_instances; do
-    ec2_instance_id=$(
+    EC2_INSTANCE_ID=$(
       $ECS_CLI describe-container-instances $DEBUG \
         --cluster "$CLUSTER" \
         --container-instances "$container" \
@@ -165,23 +182,32 @@ execCommand() {
         --query 'containerInstances[*].ec2InstanceId' |
         jq -r '.[]'
     )
-    docker_ps_output=$(
-      $SSM_CLI start-session $DEBUG \
-        --target $ec2_instance_id \
-        --document-name 'AWS-StartNonInteractiveCommand' \
-        --parameters '{"command": ["sudo docker ps --filter name='"$SERVICE"'"]}'
-    )
-    container_id=$(echo $docker_ps_output | cut -d ' ' -f 14)
+    SSM_COMMAND_ID=$($SSM_CLI send-command $DEBUG \
+                     --instance-ids "$EC2_INSTANCE_ID" \
+                     --document-name 'AWS-RunShellScript' \
+                     --parameters '{"commands": ["sudo docker ps --filter name='"$SERVICE"'"]}' |
+                     jq -r '.Command.CommandId')
+    waitForSSMCommand
+    if [ $COMMAND_EXIT_CODE -gt 0 ]; then
+      continue
+    fi
+    container_id=$(echo $COMMAND_OUTPUT | cut -d ' ' -f 9)
 
-    printf "Starting session in docker container %s of EC2 instance %s...\n" $container_id $ec2_instance_id
+    printf "Executing in docker container %s of EC2 instance %s...\n" $container_id $EC2_INSTANCE_ID
 
-    $SSM_CLI start-session $DEBUG \
-      --target $ec2_instance_id \
-      --document-name 'AWS-StartNonInteractiveCommand' \
-      --parameters '{"command": ["sudo docker exec '"$container_id"' '"$COMMAND"'"]}'
-
-    EXEC_SUCCESS=true
-    printf "Done executing command '%s'...\n" "$COMMAND"
+    SSM_COMMAND_ID=$($SSM_CLI send-command $DEBUG \
+                     --instance-ids "$EC2_INSTANCE_ID" \
+                     --document-name 'AWS-RunShellScript' \
+                     --parameters '{"commands": ["sudo docker exec '"$container_id"' '"$COMMAND"'"]}' |
+                     jq -r '.Command.CommandId')
+    waitForSSMCommand
+    if [ $COMMAND_EXIT_CODE -eq 0 ]; then
+      echo "----------------------------------------"
+      echo "$COMMAND_OUTPUT"
+      echo "----------------------------------------"
+      EXEC_SUCCESS=true
+      printf "Done executing command '%s'...\n" "$COMMAND"
+    fi
     break
   done
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -2,11 +2,12 @@
 
 AWS_CLI=$(which aws)
 ECS_CLI="$AWS_CLI --output json ecs"
+SSM_CLI="$AWS_CLI --output json ssm"
 
 CLUSTER=false
 SERVICE=false
 COMMAND=false
-WAIT=false
+EXEC=false
 IMAGE="latest"
 TASK_DEFINITION=false
 MAX_DEFINITIONS=2
@@ -136,6 +137,61 @@ function deployService() {
   printf "Done deploying service %s to %s...\n" $SERVICE $CLUSTER
 }
 
+execCommand() {
+  printf "Executing command '%s' in service %s of %s...\n" "$COMMAND" $SERVICE $CLUSTER
+
+  EXEC_SUCCESS=false
+
+  current_task_arns="$(
+    $ECS_CLI list-tasks $DEBUG \
+      --cluster "$CLUSTER" \
+      --family "$SERVICE" \
+      --query 'taskArns' |
+      jq -r '.[]'
+  )"
+  container_instances="$(
+    $ECS_CLI describe-tasks $DEBUG \
+      --cluster "$CLUSTER" \
+      --tasks $current_task_arns \
+      --query 'tasks[*].containerInstanceArn' |
+      jq -r '.[]'
+  )"
+  for container in $container_instances; do
+    ec2_instance_id=$(
+      $ECS_CLI describe-container-instances $DEBUG \
+        --cluster "$CLUSTER" \
+        --container-instances "$container" \
+        --region eu-central-1 \
+        --query 'containerInstances[*].ec2InstanceId' |
+        jq -r '.[]'
+    )
+    docker_ps_output=$(
+      $SSM_CLI start-session $DEBUG \
+        --target $ec2_instance_id \
+        --document-name 'AWS-StartNonInteractiveCommand' \
+        --parameters '{"command": ["sudo docker ps --filter name='"$SERVICE"'"]}'
+    )
+    container_id=$(echo $docker_ps_output | cut -d ' ' -f 14)
+
+    printf "Starting session in docker container %s of EC2 instance %s...\n" "$COMMAND" $container_id $ec2_instance_id
+
+    $SSM_CLI start-session $DEBUG \
+      --target $ec2_instance_id \
+      --document-name 'AWS-StartNonInteractiveCommand' \
+      --parameters '{"command": ["sudo docker exec '"$container_id"' '"$COMMAND"'"]}'
+
+    EXEC_SUCCESS=true
+    printf "Done executing command '%s'...\n" "$COMMAND"
+    break
+  done
+
+  if [[ "${EXEC_SUCCESS}" != "true" ]]; then
+    echo "No Docker container was found for executing the command!"
+    echo "Aborting!"
+    exit 1
+  fi
+}
+
 function runTask() {
   printf "Running task %s on %s...\n" $TASK_DEFINITION_ARN $CLUSTER
   
@@ -151,45 +207,12 @@ function runTask() {
     printf "Using overrides: %s\n" $overrides
   fi
 
-  task=$($ECS_CLI run-task $DEBUG \
+  $ECS_CLI run-task $DEBUG \
     --cluster $CLUSTER \
     --task-definition $TASK_DEFINITION_ARN \
-    --overrides "$overrides")
-
-  printf "$task\n"
-
-  TASK_ARN=$(echo "$task" | jq -r ".tasks[0].taskArn")
+    --overrides "$overrides"
 
   printf "Done running task %s on %s...\n" $TASK_DEFINITION_ARN $CLUSTER
-}
-
-function waitForTask() {
-  printf "Waiting for task %s on %s to finish..." $TASK_ARN $CLUSTER
-
-  every=2
-  count=0
-
-  while [ $count -lt $TIMEOUT ]; do
-    task=$($ECS_CLI describe-tasks $DEBUG \
-      --cluster $CLUSTER \
-      --tasks $TASK_ARN)
-    LAST_STATUS=$(echo "$task" | jq -r ".tasks[0].lastStatus")
-    if [ $LAST_STATUS == "STOPPED" ]; then
-      echo "Done waiting for task to finish..."
-      EXIT_CODE=$(echo $task | jq -r ".tasks[0].containers[0].exitCode")
-      if [ $EXIT_CODE -eq 0 ]; then
-        echo "Task finished successfully!"
-        count=$TIMEOUT
-      else
-        echo "Task not successful!"
-        echo "Aborting!"
-        exit 1
-      fi
-    else
-      sleep $every
-      count=$(($count + $every))
-    fi
-  done
 }
 
 function waitForDeployment() {
@@ -260,8 +283,8 @@ do
     COMMAND="$2"
     shift
     ;;
-    -w | --wait)
-    WAIT=true
+    -e | --exec)
+    EXEC=true
     ;;
     -d|--task-definition)
     TASK_DEFINITION="$2"
@@ -291,22 +314,23 @@ printf "Starting deployment of %s to ECS...\n" $SERVICE
 
 assumeRole
 
-getCurrentTaskDefinition
-printf "Current task definition ARN: %s\n" $TASK_DEFINITION_ARN
-
-updateTaskDefinition
-printf "New task definition ARN: %s\n" $TASK_DEFINITION_ARN
-
-if [ $SERVICE == false ]; then
-  if [[ $COMMAND != false ]]; then
-    runTask
-    if [[ $WAIT != false ]]; then
-      waitForTask
-    fi
-  fi
+if [[ $SERVICE != false && "$COMMAND" != false && $EXEC != false ]]; then
+  execCommand
 else
-  deployService
-  waitForDeployment
+  getCurrentTaskDefinition
+  printf "Current task definition ARN: %s\n" $TASK_DEFINITION_ARN
+
+  updateTaskDefinition
+  printf "New task definition ARN: %s\n" $TASK_DEFINITION_ARN
+
+  if [ $SERVICE == false ]; then
+    if [[ "$COMMAND" != false ]]; then
+      runTask
+    fi
+  else
+    deployService
+    waitForDeployment
+  fi
 fi
 
 resetAssumedRole

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -2,7 +2,7 @@
 
 AWS_CLI=$(which aws)
 ECS_CLI="$AWS_CLI --output json ecs"
-SSM_CLI="$AWS_CLI --output json ssm"
+SSM_CLI="unbuffer $AWS_CLI --output json ssm"
 
 CLUSTER=false
 SERVICE=false
@@ -173,7 +173,7 @@ execCommand() {
     )
     container_id=$(echo $docker_ps_output | cut -d ' ' -f 14)
 
-    printf "Starting session in docker container %s of EC2 instance %s...\n" "$COMMAND" $container_id $ec2_instance_id
+    printf "Starting session in docker container %s of EC2 instance %s...\n" $container_id $ec2_instance_id
 
     $SSM_CLI start-session $DEBUG \
       --target $ec2_instance_id \

--- a/update.sh
+++ b/update.sh
@@ -12,12 +12,12 @@ if [ -z ${PLUGIN_CLUSTER} ]; then
   exit 1
 fi
 
-if [[ -z ${PLUGIN_SERVICES} && -z $PLUGIN_TASKS && -z $PLUGIN_COMMANDS ]]; then
-  echo "You must specify either services, tasks or commands (or several of them)"
+if [[ -z ${PLUGIN_SERVICES} && -z $PLUGIN_TASKS && -z $PLUGIN_EXEC_COMMANDS ]]; then
+  echo "You must specify either services, tasks or exec_commands (or several of them)"
   exit 1
 fi
 
-if [[ ! -z ${PLUGIN_COMMANDS} && -z ${PLUGIN_EXEC_SERVICE} ]]; then
+if [[ ! -z ${PLUGIN_EXEC_COMMANDS} && -z ${PLUGIN_EXEC_SERVICE} ]]; then
   echo "You must specify an execution service, when using commands"
   exit 1
 fi
@@ -37,11 +37,11 @@ fi
 
 IFS=','
 services=($PLUGIN_SERVICES)
-commands=($PLUGIN_COMMANDS)
+exec_commands=($PLUGIN_EXEC_COMMANDS)
 tasks=($PLUGIN_TASKS)
 
 # Run commands
-for command in "${!commands[@]}"; do
+for command in "${!exec_commands[@]}"; do
   ecs-deploy $DEBUG --exec \
              -r ${PLUGIN_REGION} \
              -c ${PLUGIN_CLUSTER} \
@@ -49,7 +49,7 @@ for command in "${!commands[@]}"; do
              -t ${PLUGIN_TIMEOUT:-300} \
              -a ${PLUGIN_ROLE} \
              -s ${PLUGIN_EXEC_SERVICE} \
-             -C "${commands[$command]}"
+             -C "${exec_commands[$command]}"
 done
 
 # Run one-off tasks


### PR DESCRIPTION
~~This add a new property `predeploy_tasks` for tasks that need to be run in order and finish successfully before the services are updated.~~

This allows specifying `exec_commands` that need to run sequentially (and finish successfully) before starting a deployment.