### PR TITLE
re-add predeploy_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,26 @@ Based on https://github.com/joshdvir/drone-ecs-deploy and https://github.com/sil
 
 You will need to set the `cluster`, `image`, `region` and `role` properties in
 your drone config and additionally the `services` (to update ECS services),
-`tasks` (for running one-off tasks) and `exec_commands` (for executing commands
-before deployment) properties.
+`tasks` (for running one-off tasks), `predeploy_tasks` (for running tasks before
+updating services) and `exec_commands` (for executing commands in the old
+containers before deployment) properties.
 
 Each entry in `services` will change the service with the same name, changing
 the image in the task definition and update the service with the new definition.
 
-If `tasks` is set, it's also required to provide the `task_definition` property,
-as it can't be determined automatically (like with services). Each line is
-equivalent to one executed task and `CMD` (in Docker) will be set to this
-value. It's not guaranteed, that the tasks will execute in order, and they will
-run simultaneously with the updating of the services.
+If `tasks` or `predeploy_tasks` is set, it's also required to provide the
+`task_definition` property, as it can't be determined automatically (like with
+services). Each line is equivalent to one executed task and `CMD` (in Docker)
+will be set to this value. For `tasks` it's not guaranteed, that the tasks will
+execute in order, and they will be triggered simultaneously with the updating of
+the services. Tasks specified via `predeploy_tasks`, on the other hand, _will_
+be run sequentially, and an unsuccessful exit code will lead to aborting the
+deployment.
 
 If `exec_commands` are set it's also required to provide an `exec_service` where
 they will be executed. This can be used to specify commands that need to run
 sequentially and complete successfully before any `services` are deployed or
-`tasks` are started.
+`tasks` or `predeploy_tasks` are started.
 
 ```yaml
 steps:
@@ -39,12 +43,14 @@ steps:
     exec_service:
       - service-a
     exec_commands:
+      - ./prepare.sh
+    task_definition: <task-definition-name>
+    predeploy_tasks:
       - ./predeploy.sh
     services:
       - service-a
       - service-b
       - service-c
-    task_definition: <task-definition-name>
     tasks:
       - ./custom_command.sh
   ...
@@ -56,7 +62,7 @@ To build a new docker image of `drone-ecs-deploy-advanced` and push it to the
 Docker hub, use the following commands:
 
 ```sh
-VERSION=1.1.0
+VERSION=1.2.0
 docker build -t "formunauts/drone-ecs-deploy-advanced:$VERSION" .
 docker push "formunauts/drone-ecs-deploy-advanced:$VERSION"
 ```

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -7,6 +7,7 @@ SSM_CLI="$AWS_CLI --output json ssm"
 CLUSTER=false
 SERVICE=false
 COMMAND=false
+WAIT=false
 EXEC=false
 IMAGE="latest"
 TASK_DEFINITION=false
@@ -233,12 +234,45 @@ function runTask() {
     printf "Using overrides: %s\n" $overrides
   fi
 
-  $ECS_CLI run-task $DEBUG \
+  task=$($ECS_CLI run-task $DEBUG \
     --cluster $CLUSTER \
     --task-definition $TASK_DEFINITION_ARN \
-    --overrides "$overrides"
+    --overrides "$overrides")
+
+  printf "$task\n"
+
+  TASK_ARN=$(echo "$task" | jq -r ".tasks[0].taskArn")
 
   printf "Done running task %s on %s...\n" $TASK_DEFINITION_ARN $CLUSTER
+}
+
+function waitForTask() {
+  printf "Waiting for task %s on %s to finish..." $TASK_ARN $CLUSTER
+
+  every=2
+  count=0
+
+  while [ $count -lt $TIMEOUT ]; do
+    task=$($ECS_CLI describe-tasks $DEBUG \
+      --cluster $CLUSTER \
+      --tasks $TASK_ARN)
+    LAST_STATUS=$(echo "$task" | jq -r ".tasks[0].lastStatus")
+    if [ $LAST_STATUS == "STOPPED" ]; then
+      echo "Done waiting for task to finish..."
+      EXIT_CODE=$(echo $task | jq -r ".tasks[0].containers[0].exitCode")
+      if [ $EXIT_CODE -eq 0 ]; then
+        echo "Task finished successfully!"
+        count=$TIMEOUT
+      else
+        echo "Task not successful!"
+        echo "Aborting!"
+        exit 1
+      fi
+    else
+      sleep $every
+      count=$(($count + $every))
+    fi
+  done
 }
 
 function waitForDeployment() {
@@ -309,6 +343,9 @@ do
     COMMAND="$2"
     shift
     ;;
+    -w | --wait)
+    WAIT=true
+    ;;
     -e | --exec)
     EXEC=true
     ;;
@@ -352,6 +389,9 @@ else
   if [ $SERVICE == false ]; then
     if [[ "$COMMAND" != false ]]; then
       runTask
+      if [[ $WAIT != false ]]; then
+        waitForTask
+      fi
     fi
   else
     deployService


### PR DESCRIPTION
Since it is impossible to detect if new migrations are pending by executing commands in the old containers, I re-added the `predeploy_tasks` property as it was originally done in 8a75d8340e5bc40a7eb10cb4df7fc3667802f510 (see https://github.com/formunauts/drone-ecs-deploy-advanced/pull/1).