### PR TITLE
Parallelize deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ jobs:
           aws-region: eu-central-1
 
       - name: Deploy to ECS
-        uses: formunauts/drone-ecs-deploy-advanced@v1.3.1
+        uses: formunauts/drone-ecs-deploy-advanced@v1.4.0
         with:
           role: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
           cluster: my-production-cluster
@@ -124,7 +124,7 @@ in `action.yml`:
 ...
 runs:
   using: "docker"
-  image: "docker://formunauts/drone-ecs-deploy-advanced:1.3.1"
+  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.0"
 ...
 ```
 
@@ -132,7 +132,7 @@ When that's done build a new docker image of `drone-ecs-deploy-advanced` and pus
 Docker hub, use the following commands:
 
 ```sh
-VERSION=1.3.1
+VERSION=1.4.0
 docker build -t "formunauts/drone-ecs-deploy-advanced:$VERSION" .
 docker push "formunauts/drone-ecs-deploy-advanced:$VERSION"
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ your drone config and additionally the `services` (to update ECS services),
 updating services) and `exec_commands` (for executing commands in the old
 containers before deployment) properties.
 
+**Note on Concurrency:** All `services` and `tasks` are deployed and run
+concurrently to speed up the deployment process.
+
 Each entry in `services` will change the service with the same name, changing
 the image in the task definition and update the service with the new definition.
 

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://formunauts/drone-ecs-deploy-advanced:1.3.1"
+  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.0"
   env:
     PLUGIN_ROLE: ${{ inputs.role }}
     PLUGIN_CLUSTER: ${{ inputs.cluster }}

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -16,24 +16,6 @@ NEW_DEF=false
 TIMEOUT=90
 DEBUG=""
 
-function assumeRole() {
-  echo "Assuming role..."
-
-  role=$(aws sts assume-role $DEBUG --role-arn $AWS_ASSUME_ROLE --role-session-name "$(date +"%s")")
-
-  export AWS_ACCESS_KEY_ID=$(echo $role | jq .Credentials.AccessKeyId | xargs)
-  export AWS_SECRET_ACCESS_KEY=$(echo $role | jq .Credentials.SecretAccessKey | xargs)
-  export AWS_SESSION_TOKEN=$(echo $role | jq .Credentials.SessionToken | xargs)
-}
-
-function resetAssumedRole() {
-  echo "Resetting asumed role..."
-
-  unset AWS_ACCESS_KEY_ID
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_SESSION_TOKEN
-}
-
 function getCurrentTaskDefinition() {
   echo "Getting current task definition..."
 
@@ -323,10 +305,6 @@ do
   key="$1"
 
   case $key in
-    -a|--aws-assume-role)
-    AWS_ASSUME_ROLE="$2"
-    shift
-    ;;
     -c|--cluster)
     CLUSTER="$2"
     shift
@@ -375,8 +353,6 @@ done
 echo "---"
 printf "Starting deployment of %s to ECS...\n" $SERVICE 
 
-assumeRole
-
 if [[ $SERVICE != false && "$COMMAND" != false && $EXEC != false ]]; then
   execCommand
 else
@@ -398,8 +374,6 @@ else
     waitForDeployment
   fi
 fi
-
-resetAssumedRole
 
 printf "Everything done for %s. Have a nice day! \n" $SERVICE
 


### PR DESCRIPTION
This should speed up deployments by starting all one-off tasks and services concurrently (but after waiting for any exec commands or pre-deploy tasks to finish, as before).

Also, the AWS role is only assumed once, instead of multiple times, for each invocation of `ecs-deploy`, which could also speed this up a bit.