### PR TITLE
Task retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ jobs:
           aws-region: eu-central-1
 
       - name: Deploy to ECS
-        uses: formunauts/drone-ecs-deploy-advanced@v1.4.1
+        uses: formunauts/drone-ecs-deploy-advanced@v1.4.2
         with:
           role: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
           cluster: my-production-cluster
@@ -124,7 +124,7 @@ in `action.yml`:
 ...
 runs:
   using: "docker"
-  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.1"
+  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.2"
 ...
 ```
 
@@ -132,7 +132,7 @@ When that's done build a new docker image of `drone-ecs-deploy-advanced` and pus
 Docker hub, use the following commands:
 
 ```sh
-VERSION=1.4.1
+VERSION=1.4.2
 docker build -t "formunauts/drone-ecs-deploy-advanced:$VERSION" .
 docker push "formunauts/drone-ecs-deploy-advanced:$VERSION"
 ```

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.1"
+  image: "docker://formunauts/drone-ecs-deploy-advanced:1.4.2"
   env:
     PLUGIN_ROLE: ${{ inputs.role }}
     PLUGIN_CLUSTER: ${{ inputs.cluster }}

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -216,16 +216,32 @@ function runTask() {
     printf "Using overrides: %s\n" $overrides
   fi
 
-  task=$($ECS_CLI run-task $DEBUG \
-    --cluster $CLUSTER \
-    --task-definition $TASK_DEFINITION_ARN \
-    --overrides "$overrides")
+  max_retries=3
+  retry_delay=10
+  for i in $(seq 1 $max_retries); do
+    task=$($ECS_CLI run-task $DEBUG \
+      --cluster $CLUSTER \
+      --task-definition $TASK_DEFINITION_ARN \
+      --overrides "$overrides")
 
-  printf "$task\n"
+    printf "Run task response:\n%s\n" "$task"
 
-  TASK_ARN=$(echo "$task" | jq -r ".tasks[0].taskArn")
+    failures=$(echo "$task" | jq '.failures | length')
+    if [ "$failures" -eq 0 ]; then
+      TASK_ARN=$(echo "$task" | jq -r ".tasks[0].taskArn")
+      printf "Successfully started task %s on %s...\n" $TASK_ARN $CLUSTER
+      return 0
+    fi
 
-  printf "Done running task %s on %s...\n" $TASK_DEFINITION_ARN $CLUSTER
+    echo "Failed to start task (attempt $i/$max_retries):"
+    echo "$task" | jq '.failures'
+    if [ "$i" -lt "$max_retries" ]; then
+      echo "Retrying in $retry_delay seconds..."
+      sleep $retry_delay
+    fi
+  done
+
+  echo "Could not start task after $max_retries attempts."
 }
 
 function waitForTask() {


### PR DESCRIPTION
When deploying the EPMS changes to staging, the problem of stuck maintenance mode came up again. This time I investigated in more detail – it appears that ECS momentarily simply didn't have enough CPU resources available to start the task (https://github.com/formunauts/backend/actions/runs/18898636785/job/53941653526):
```json
{
    "tasks": [],
    "failures": [
        {
            "arn": "arn:aws:ecs:eu-central-1:794817242931:container-instance/a10cbe889a2c406fa970b113fe42d56d",
            "reason": "RESOURCE:CPU"
        },
        {
            "arn": "arn:aws:ecs:eu-central-1:794817242931:container-instance/f371c061c58b42cba1b8832db3074447",
            "reason": "RESOURCE:CPU"
        }
    ]
}
```

So, adding some error handling and retry functionality should hopefully fix that.